### PR TITLE
Harden dotfiles scripts and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ tar -xzv --strip-components 1; \
 
 ---
 ##### Credit
-Inspired and borrowed form Ryan Bates, Ryan Tomayko, Carlhuda, Robert Evans,
+Inspired and borrowed from Ryan Bates, Ryan Tomayko, Carlhuda, Robert Evans,
 Mathias Bynens and Mislav Marohnić dotfile repos.

--- a/gitconfig
+++ b/gitconfig
@@ -84,3 +84,8 @@
 [pager]
   diff = diff-so-fancy | less --tabs=4 -RFX
   show = diff-so-fancy | less --tabs=4 -RFX
+
+[commit]
+  gpgsign = true
+[gpg]
+  program = gpg

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 clear
 echo "      _       _    __ _ _             "

--- a/psqlrc
+++ b/psqlrc
@@ -33,7 +33,7 @@
 \set PROMPT2 ''
 
 \set PAGER OFF
-\set HISTFILE ~/.psql_history- :HOST - :DBNAME
+\set HISTFILE ~/.psql_history-:HOST-:DBNAME
 \set HISTSIZE 5000
 \set HISTCONTROL ignoredups
 \set ECHO_HIDDEN ON
@@ -55,7 +55,7 @@
 \echo '\t:conninfo\t-- Server connections'
 \echo '\t:activity\t-- Server activity'
 \echo '\t:locks\t\t-- Lock info'
-\echo '\t:waits\t\t-- Waiting queires'
+\echo '\t:waits\t\t-- Waiting queries'
 \echo '\t:dbsize\t\t-- Database Size'
 \echo '\t:tablesize\t-- Tables Size'
 \echo '\t:uselesscol\t-- Useless columns'


### PR DESCRIPTION
## Summary
- enable strict error handling in `install.sh`
- fix typo in README credit section
- tidy `psqlrc` history path and query description
- enable git GPG signing by default

## Testing
- `bash -n install.sh`
- `psql --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6760b5c40832da20dbd1cb242104d