### PR TITLE
Add Bash and Node.js versions of mac-zapper and template validation

### DIFF
--- a/bash/bin/cask_report_bash
+++ b/bash/bin/cask_report_bash
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Dependencies: tail, head, grep, cat, git, ansifilter
+# TODO
+# 1. argument to prevent sha update
+
+report() {
+  local type="$1"
+  local latest_sha_file="$HOME/.homebrew-${type}-latest-sha"
+  local cask_repo="/opt/homebrew/Library/Taps/homebrew/homebrew-${type}"
+  local version_regex='^[+-]\s*version\s+["\'""']?(.+?)["\'""']?$'
+  local homepage_regex='^\s+homepage\s+["\'""'](.+)["\'""']\s*$'
+  local -a updated added removed update_available
+
+  cd "$cask_repo" || return 1
+
+  local old_sha
+  if [[ -f "$latest_sha_file" ]]; then
+    old_sha=$(<"$latest_sha_file")
+  else
+    old_sha=$(git log | head -20 | /usr/bin/tail -r | head -1 | ansifilter | sed -nE 's/([a-z0-9]{7})\s.+/\1/p')
+  fi
+  local latest_sha
+  latest_sha=$(git log | head -1 | ansifilter | sed -nE 's/([a-z0-9]{7,})\s.+/\1/p')
+
+  mapfile -t installed_casks < <(brew list --cask)
+  local changes
+  changes=$(git diff --name-status "$old_sha" | grep Casks/ | ansifilter)
+
+  while IFS=$'\t' read -r status path; do
+    [[ -z "$path" ]] && continue
+    local app
+    app=$(sed -nE 's/^Casks\/(.+)\.rb$/\1/p' <<<"$path")
+    [[ -z "$app" ]] && continue
+
+    if [[ "$status" == 'D' ]]; then
+      removed+=("\033[94m${app}\033[0m")
+    else
+      local h homepage
+      h=$(cat "Casks/${app}.rb" | grep -E '^\s+homepage')
+      if [[ -z "$h" ]]; then
+        homepage=""
+      else
+        homepage=$(sed -nE "${homepage_regex}" <<<"$h" | sed -nE 's/'"$homepage_regex"'/\1/p')
+      fi
+      if [[ "$status" == 'A' ]]; then
+        added+=("\033[94m${app}\033[0m [\033[92m${homepage}\033[0m]")
+      elif [[ "$status" == 'M' ]]; then
+        local version_diff last_version current_version
+        version_diff=$(git diff "$old_sha" "Casks/${app}.rb" | grep -E '^[+-]\s+version')
+        if [[ -n "$version_diff" ]]; then
+          last_version=$(sed -n 1p <<<"$version_diff" | sed -nE 's/'"$version_regex"'/\1/p')
+          current_version=$(sed -n 2p <<<"$version_diff" | sed -nE 's/'"$version_regex"'/\1/p')
+        fi
+        local needs_update=""
+        if [[ -n "$version_diff" ]]; then
+          if printf '%s\n' "${installed_casks[@]}" | grep -qx "$app"; then
+            needs_update=1
+            update_available+=("✨  \033[32m${app}\033[0m")
+          fi
+        fi
+        updated+=("\033[94m${app}\033[0m${needs_update:+✨} [\033[92m${homepage}\033[0m]${version_diff:+ \${last_version} \033[33m<\033[0m \${current_version}}")
+      fi
+    fi
+  done <<<"$changes"
+
+  echo -e "\n\033[35m🔮  ${type^^}\033[0m"
+  if ((${#updated[@]})); then
+    echo -e "\033[95mUPDATED\033[0m"
+    printf '%s\n' "${updated[@]}"
+  fi
+  if ((${#added[@]})); then
+    echo -e "\033[95mADDED\033[0m"
+    printf '%s\n' "${added[@]}"
+  fi
+  if ((${#removed[@]})); then
+    echo -e "\033[95mREMOVED\033[0m"
+    printf '%s\n' "${removed[@]}"
+  fi
+  if ((${#update_available[@]})); then
+    echo -e "\033[95mOUTDATED\033[0m"
+    printf '%s\n' "${update_available[@]}"
+  fi
+  echo -e "\033[90mOld SHA: ${old_sha}  New SHA: ${latest_sha}\033[0m"
+
+  printf '%s' "$latest_sha" >"$latest_sha_file"
+}
+
+report cask

--- a/bash/bin/cask_report_nodejs
+++ b/bash/bin/cask_report_nodejs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// Dependencies: tail, head, grep, cat, git, ansifilter
+// TODO
+// 1. argument to prevent sha update
+
+const fs = require('fs');
+const os = require('os');
+const { execSync } = require('child_process');
+
+function color(code, str) {
+  return `\u001b[${code}m${str}\u001b[0m`;
+}
+
+function report(type) {
+  const latestShaFile = `${os.homedir()}/.homebrew-${type}-latest-sha`;
+  const caskRepo = `/opt/homebrew/Library/Taps/homebrew/homebrew-${type}`;
+  const versionRegex = /^[+-]\s*version\s+['"]?(.+?)['"]?$/;
+  const homepageRegex = /^\s+homepage\s+["'](.+)["']\s*$/;
+  const updated = [];
+  const added = [];
+  const removed = [];
+  const updateAvailable = [];
+
+  process.chdir(caskRepo);
+
+  let oldSha;
+  if (fs.existsSync(latestShaFile)) {
+    oldSha = fs.readFileSync(latestShaFile, 'utf8').trim();
+  } else {
+    const output = execSync('git log | head -20 | /usr/bin/tail -r | head -1 | ansifilter', { encoding: 'utf8' });
+    const m = output.match(/([a-z0-9]{7})\s.+/);
+    oldSha = m ? m[1] : '';
+  }
+  const latestShaOutput = execSync('git log | head -1 | ansifilter', { encoding: 'utf8' });
+  const latestShaMatch = latestShaOutput.match(/([a-z0-9]{7,})\s.+/);
+  const latestSha = latestShaMatch ? latestShaMatch[1] : '';
+
+  const installedCasks = execSync('brew list --cask', { encoding: 'utf8' }).trim().split('\n');
+  const changes = execSync(`git diff --name-status ${oldSha} | grep Casks/ | ansifilter`, { encoding: 'utf8' }).trim().split('\n');
+
+  const apps = changes.map(c => {
+    const [status, path] = c.split('\t');
+    const m = path.match(/^Casks\/(.+)\.rb$/);
+    return m ? { status, name: m[1] } : null;
+  }).filter(Boolean);
+
+  apps.forEach(a => {
+    if (a.status === 'D') {
+      removed.push(color('94', a.name));
+    } else {
+      const h = execSync(`cat Casks/${a.name}.rb | grep -E '^\\s+homepage'`, { encoding: 'utf8' });
+      const homepageMatch = h.match(homepageRegex);
+      const homepage = homepageMatch ? homepageMatch[1] : '';
+      if (a.status === 'A') {
+        added.push(`${color('94', a.name)} [${color('92', homepage)}]`);
+      } else if (a.status === 'M') {
+        let versionDiff = '';
+        try {
+          versionDiff = execSync(`git diff ${oldSha} Casks/${a.name}.rb | grep -E '^[+-]\\s+version'`, { encoding: 'utf8' });
+        } catch {}
+        let lastVersion, currentVersion;
+        if (versionDiff) {
+          [lastVersion, currentVersion] = versionDiff.split('\n');
+          if (lastVersion) {
+            const lm = lastVersion.match(versionRegex);
+            lastVersion = lm ? lm[1] : undefined;
+          }
+          if (currentVersion) {
+            const cm = currentVersion.match(versionRegex);
+            currentVersion = cm ? cm[1] : undefined;
+          }
+        }
+        let needsUpdate = false;
+        if (versionDiff && installedCasks.includes(a.name)) {
+          needsUpdate = true;
+          updateAvailable.push(`✨  ${color('32', a.name)}`);
+        }
+        updated.push([
+          color('94', a.name),
+          needsUpdate ? '✨' : '',
+          ` [${color('92', homepage)}]`,
+          versionDiff ? ` ${lastVersion} ${color('33', '<')} ${currentVersion}` : ''
+        ].join(''));
+      }
+    }
+  });
+
+  console.log(`\n${color('35', '🔮  ' + type.toUpperCase())}`);
+  if (updated.length) {
+    console.log(color('95', 'UPDATED'));
+    console.log(updated.join('\n'));
+  }
+  if (added.length) {
+    console.log(color('95', 'ADDED'));
+    console.log(added.join('\n'));
+  }
+  if (removed.length) {
+    console.log(color('95', 'REMOVED'));
+    console.log(removed.join('\n'));
+  }
+  if (updateAvailable.length) {
+    console.log(color('95', 'OUTDATED'));
+    console.log(updateAvailable.join('\n'));
+  }
+  console.log(color('90', `Old SHA: ${oldSha}  New SHA: ${latestSha}`));
+
+  fs.writeFileSync(latestShaFile, latestSha);
+}
+
+report('cask');

--- a/bash/bin/mac-zapper_bash
+++ b/bash/bin/mac-zapper_bash
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+SEARCH_PATHS='/Users /Library /Applications /opt /var /usr'
+EXCLUDES=(
+  '/Library/Dictionaries'
+  '/Library/Caches/Homebrew'
+  '/usr/local/.dscage'
+  '/usr/local/Cellar'
+  '/usr/local/Library'
+  "$HOME/Library/Application Support/Google/Chrome/Default/Extensions"
+  "$HOME/.vim"
+  "$HOME/.npm"
+)
+
+res_array=()
+
+initialize() {
+  local app="$1"
+  local ex_cmd=''
+  for ex in "${EXCLUDES[@]}"; do
+    ex_cmd+="-not -path \"${ex}/*\" "
+  done
+  local cmd="sudo find ${SEARCH_PATHS} ${ex_cmd}-iregex '.*${app}.*' -prune"
+  mapfile -t res_array < <(eval "$cmd")
+  exclude_or_zap
+}
+
+exclude_or_zap() {
+  local i res action
+  for i in "${!res_array[@]}"; do
+    res="${res_array[i]}"
+    printf '[%d] %s\n' "$((i + 1))" "$res"
+  done
+  read -rp '==> zap or exclude? [z/e/q] ' action
+  case "$action" in
+    z) zap ;;
+    e) exclude ;;
+    q) exit ;;
+    *) exclude_or_zap ;;
+  esac
+}
+
+zap() {
+  echo '==> zapping, are you sure? [y/n]'
+  read -r action
+  if [[ "$action" == 'y' ]]; then
+    local z cmd
+    for z in "${res_array[@]}"; do
+      cmd="sudo rm -Rf \"${z}\""
+      eval "$cmd"
+    done
+  fi
+}
+
+exclude() {
+  echo '==> Exlude [enter indexed separated with ,]'
+  read -r index_list
+  IFS=',' read -ra index_array <<< "$index_list"
+  local del_arr=() idx
+  for idx in "${index_array[@]}"; do
+    idx="${idx// /}"
+    del_arr+=("${res_array[idx-1]}")
+  done
+  local del i
+  for del in "${del_arr[@]}"; do
+    for i in "${!res_array[@]}"; do
+      if [[ "${res_array[i]}" == "$del" ]]; then
+        unset 'res_array[i]'
+      fi
+    done
+  done
+  res_array=("${res_array[@]}")
+  exclude_or_zap
+}
+
+initialize "$1"

--- a/bash/bin/mac-zapper_nodejs
+++ b/bash/bin/mac-zapper_nodejs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const readline = require('readline');
+
+const SEARCH_PATHS = '/Users /Library /Applications /opt /var /usr';
+const EXCLUDES = [
+  '/Library/Dictionaries',
+  '/Library/Caches/Homebrew',
+  '/usr/local/.dscage',
+  '/usr/local/Cellar',
+  '/usr/local/Library',
+  `${process.env.HOME}/Library/Application Support/Google/Chrome/Default/Extensions`,
+  `${process.env.HOME}/.vim`,
+  `${process.env.HOME}/.npm`
+];
+
+class Zapper {
+  constructor(app) {
+    let exCmd = '';
+    EXCLUDES.forEach(ex => { exCmd += `-not -path "${ex}/*" `; });
+    const cmd = `sudo find ${SEARCH_PATHS} ${exCmd}-iregex '.*${app}.*' -prune`;
+    const results = execSync(cmd, { encoding: 'utf8' });
+    this.resArray = results.split('\n').filter(Boolean);
+    this.excludeOrZap();
+  }
+
+  excludeOrZap() {
+    this.resArray.forEach((res, i) => {
+      console.log(`[${i + 1}] ${res}`);
+    });
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question('==> zap or exclude? [z/e/q] ', (action) => {
+      rl.close();
+      action = action.trim();
+      switch (action) {
+        case 'z':
+          this.zap();
+          break;
+        case 'e':
+          this.exclude();
+          break;
+        case 'q':
+          process.exit(0);
+        default:
+          this.excludeOrZap();
+      }
+    });
+  }
+
+  zap() {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question('==> zapping, are you sure? [y/n]\n', (action) => {
+      rl.close();
+      if (action.trim() === 'y') {
+        this.resArray.forEach(z => {
+          const cmd = `sudo rm -Rf "${z}"`;
+          execSync(cmd, { stdio: 'inherit' });
+        });
+      }
+    });
+  }
+
+  exclude() {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question('==> Exlude [enter indexed separated with ,]\n', (indexList) => {
+      rl.close();
+      const indexArray = indexList.split(',').map(i => parseInt(i.trim(), 10));
+      const delArr = [];
+      indexArray.forEach(i => { delArr.push(this.resArray[i - 1]); });
+      this.resArray = this.resArray.filter(res => !delArr.includes(res));
+      this.excludeOrZap();
+    });
+  }
+}
+
+new Zapper(process.argv[2]);

--- a/bash/bin/template_validation_bash
+++ b/bash/bin/template_validation_bash
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+print_results() {
+  local section="$1"
+  local -n live_ref=$2
+  local -n template_ref=$3
+  echo -e "\033[94m${section}\033[0m"
+  local not_in_template=()
+  local item t found
+  for item in "${live_ref[@]}"; do
+    found=0
+    for t in "${template_ref[@]}"; do
+      [[ "$item" == "$t" ]] && { found=1; break; }
+    done
+    if ((found == 0)); then
+      not_in_template+=("$item")
+    fi
+  done
+  if ((${#not_in_template[@]} > 0)); then
+    echo -e "\033[95mNot in template\033[0m\n"
+    printf '%s\n' "${not_in_template[@]}"
+  fi
+
+  local not_installed=()
+  for item in "${template_ref[@]}"; do
+    found=0
+    for t in "${live_ref[@]}"; do
+      [[ "$item" == "$t" ]] && { found=1; break; }
+    done
+    if ((found == 0)); then
+      not_installed+=("$item")
+    fi
+  done
+  if ((${#not_installed[@]} > 0)); then
+    echo -e "\033[95mNot installed\033[0m\n"
+    printf '%s\n' "${not_installed[@]}"
+  fi
+}
+
+# ========================================================
+
+mapfile -t live < <(brew leaves | sort)
+mapfile -t template < <(cat ~/.templates/dependencies/brew | sort | while read -r i; do
+  i="${i//homebrew/completions\/}"
+  i="${i//homebrew/dupes\/}"
+  i="${i%% --*}"
+  printf '%s\n' "$i"
+done)
+
+print_results 'HOMEBREW:' live template
+
+# ========================================================
+
+mapfile -t live < <(brew list --cask | sort)
+mapfile -t template_apps < <(cat ~/.templates/dependencies/apps | sort)
+mapfile -t template_apps_browsers < <(cat ~/.templates/dependencies/apps_browsers | sort)
+mapfile -t template_fonts < <(cat ~/.templates/dependencies/fonts | sort | while read -r i; do
+  if [[ ${#i} -eq 0 || ${i:0:1} == '#' ]]; then
+    continue
+  fi
+  printf '%s\n' "$i"
+done)
+template=("${template_apps[@]}" "${template_apps_browsers[@]}" "${template_fonts[@]}")
+print_results 'HOMEBREW CASK:' live template
+
+# ========================================================
+
+mapfile -t live < <(npm list -g --depth=0 | while read -r i; do
+  i="${i//├/}"
+  i="${i//└/}"
+  i="${i//─/}"
+  i="${i#${i%%[![:space:]]*}}"
+  i="${i%%@*}"
+  if [[ "$i" != '/opt/homebrew/lib' && "$i" != 'npm' ]]; then
+    printf '%s\n' "$i"
+  fi
+done)
+mapfile -t template < <(cat ~/.templates/dependencies/npm)
+
+print_results 'NPM:' live template

--- a/bash/bin/template_validation_nodejs
+++ b/bash/bin/template_validation_nodejs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+
+function printResults(section, live, template) {
+  console.log(`\x1b[94m${section}\x1b[0m`);
+  if (live.filter(i => !template.includes(i)).length > 0) {
+    console.log(`\x1b[95mNot in template\x1b[0m\n`);
+    console.log(live.filter(i => !template.includes(i)));
+  }
+
+  if (template.filter(i => !live.includes(i)).length > 0) {
+    console.log(`\x1b[95mNot installed\x1b[0m\n`);
+    console.log(template.filter(i => !live.includes(i)));
+  }
+}
+
+// ========================================================
+
+let live = execSync('brew leaves | sort', { encoding: 'utf8' }).split('\\n');
+let template = execSync('cat ~/.templates/dependencies/brew | sort', { encoding: 'utf8' })
+  .split('\\n').map(i => {
+    i = i.replace('homebrew/completions/', '');
+    i = i.replace('homebrew/dupes/', '');
+    i = i.replace(/\\s--.+/, '');
+    return i;
+  });
+
+printResults('HOMEBREW:', live, template);
+
+// ========================================================
+
+live = execSync('brew list --cask | sort', { encoding: 'utf8' }).split('\\n');
+const template_apps = execSync('cat ~/.templates/dependencies/apps | sort', { encoding: 'utf8' }).split('\\n');
+const template_apps_browsers = execSync('cat ~/.templates/dependencies/apps_browsers | sort', { encoding: 'utf8' }).split('\\n');
+const template_fonts = execSync('cat ~/.templates/dependencies/fonts | sort', { encoding: 'utf8' })
+  .split('\\n').filter(i => !(i.length === 0 || i[0] === '#'));
+template = template_apps.concat(template_apps_browsers, template_fonts);
+printResults('HOMEBREW CASK:', live, template);
+
+// ========================================================
+
+// live = `gem list --no-details --no-version`.split("\\n")
+// template = `cat ~/.templates/dependencies/gem`.split("\\n")
+// print_results('GEMS:', live, template)
+
+// ========================================================
+
+live = execSync('npm list -g --depth=0', { encoding: 'utf8' }).split('\\n').map(i => {
+  i = i.replace(/[├──└─]+/g, '');
+  i = i.replace(/^\\s+/, '');
+  i = i.replace(/@\\d.+/, '');
+  return i;
+}).filter(i => !(i === '/opt/homebrew/lib' || i === 'npm'));
+template = execSync('cat ~/.templates/dependencies/npm', { encoding: 'utf8' }).split('\\n');
+
+printResults('NPM:', live, template);


### PR DESCRIPTION
## Summary
- Port `mac-zapper` to Bash and Node.js while preserving the original Ruby script
- Port `template_validation` to Bash and Node.js alongside its Ruby version

## Testing
- `bash -n bash/bin/mac-zapper_bash`
- `node --check bash/bin/mac-zapper_nodejs`
- `bash -n bash/bin/template_validation_bash`
- `node --check bash/bin/template_validation_nodejs`
- `printf 'q\n' | bash bash/bin/mac-zapper_bash foo` *(fails: missing macOS paths)*
- `printf 'q\n' | node bash/bin/mac-zapper_nodejs foo` *(fails: missing macOS paths)*
- `bash bash/bin/template_validation_bash` *(fails: brew: command not found)*
- `node bash/bin/template_validation_nodejs` *(fails: brew: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6791ee1b0832dbff8ff33251c1e56